### PR TITLE
feat: Add rule to delete feature branches after merge

### DIFF
--- a/MANDATORY-RULES.md
+++ b/MANDATORY-RULES.md
@@ -92,7 +92,7 @@
 # STEP 6: CLEANUP (MANDATORY)
 - ✅ After merging, close the issue if it's fully resolved.
 - ✅ Comment on the issue with the resolution and PR link.
-- ✅ Delete the feature branch after the PR is merged.
+- ✅ **DELETE THE FEATURE BRANCH** after the PR is merged.
 - 🚨 VIOLATION = Leaving stale branches or open issues.
 ```
 


### PR DESCRIPTION
This PR introduces a new rule to the  file that requires feature branches to be deleted after a successful merge to the  branch. This change is designed to keep the repository clean and prevent the accumulation of stale branches. Closes #75