### PR TITLE
fix: create missing Claude hook scripts #228

### DIFF
--- a/.claude/hooks/continuous-pr-monitor.sh
+++ b/.claude/hooks/continuous-pr-monitor.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Continuous PR monitoring script
+# Monitors PR status and enables auto-merge when ready
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🔍 Monitoring PR status...${NC}"
+
+# Check if gh CLI is available
+if ! command -v gh &> /dev/null; then
+    echo -e "${YELLOW}⚠️  GitHub CLI (gh) not found. Skipping PR monitoring.${NC}"
+    exit 0
+fi
+
+# Get current branch
+current_branch=$(git branch --show-current)
+
+# Skip if on main or preview
+if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "preview" ]]; then
+    exit 0
+fi
+
+# Check if PR exists for current branch
+pr_number=$(gh pr list --head "$current_branch" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+if [ -z "$pr_number" ]; then
+    echo -e "${YELLOW}ℹ️  No PR found for branch: $current_branch${NC}"
+    exit 0
+fi
+
+echo -e "${GREEN}✓ Found PR #$pr_number for branch: $current_branch${NC}"
+
+# Check PR status
+pr_data=$(gh pr view "$pr_number" --json state,mergeable,mergeStateStatus,reviews,statusCheckRollup 2>/dev/null || echo "{}")
+
+if [ "$pr_data" == "{}" ]; then
+    echo -e "${RED}❌ Failed to fetch PR data${NC}"
+    exit 1
+fi
+
+state=$(echo "$pr_data" | jq -r '.state')
+mergeable=$(echo "$pr_data" | jq -r '.mergeable')
+merge_state=$(echo "$pr_data" | jq -r '.mergeStateStatus')
+
+echo -e "${BLUE}📊 PR Status:${NC}"
+echo -e "   State: $state"
+echo -e "   Mergeable: $mergeable"
+echo -e "   Merge State: $merge_state"
+
+# Check for required actions
+if [ "$state" == "OPEN" ]; then
+    # Check for review approval
+    approved=$(echo "$pr_data" | jq -r '.reviews[] | select(.state == "APPROVED") | .state' | head -1)
+    
+    if [ -z "$approved" ]; then
+        echo -e "${YELLOW}⚠️  PR needs review approval${NC}"
+        echo -e "   Run: gh pr review $pr_number --approve"
+    fi
+    
+    # Check status checks
+    checks_status=$(echo "$pr_data" | jq -r '.statusCheckRollup[] | select(.conclusion != "SUCCESS") | .name' 2>/dev/null)
+    
+    if [ -n "$checks_status" ]; then
+        echo -e "${YELLOW}⚠️  Some checks are not passing:${NC}"
+        echo "$checks_status" | while read -r check; do
+            echo -e "   ❌ $check"
+        done
+    fi
+    
+    # Enable auto-merge if ready
+    if [ "$mergeable" == "MERGEABLE" ] && [ "$merge_state" == "CLEAN" ]; then
+        echo -e "${GREEN}✅ PR is ready to merge!${NC}"
+        
+        # Check if auto-merge is already enabled
+        auto_merge=$(gh pr view "$pr_number" --json autoMergeRequest --jq '.autoMergeRequest' 2>/dev/null || echo "null")
+        
+        if [ "$auto_merge" == "null" ]; then
+            echo -e "${BLUE}🔄 Enabling auto-merge...${NC}"
+            gh pr merge "$pr_number" --auto --squash 2>/dev/null || echo -e "${YELLOW}⚠️  Could not enable auto-merge (may need branch protection)${NC}"
+        else
+            echo -e "${GREEN}✓ Auto-merge already enabled${NC}"
+        fi
+    fi
+fi
+
+# Log PR monitoring to remind file
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Monitored PR #$pr_number on branch $current_branch" >> .claude/pr-reminders.log

--- a/.claude/hooks/enforce-pr-workflow.sh
+++ b/.claude/hooks/enforce-pr-workflow.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Enforce PR workflow rules before push
+# Ensures all workflow requirements are met
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🔍 Enforcing PR workflow rules...${NC}"
+
+# Function to check if we're in a git repository
+check_git_repo() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        echo -e "${RED}❌ Not in a git repository${NC}"
+        exit 1
+    fi
+}
+
+# Function to check branch naming
+check_branch_naming() {
+    local current_branch=$(git branch --show-current)
+    
+    # Allow main and preview branches
+    if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "preview" ]]; then
+        return 0
+    fi
+    
+    # Check feature branch pattern
+    if [[ ! "$current_branch" =~ ^(feature|bugfix|hotfix)/issue-[0-9]+-.*$ ]]; then
+        echo -e "${RED}❌ Branch naming violation${NC}"
+        echo -e "   Current: $current_branch"
+        echo -e "   Expected: feature/issue-{number}-{description}"
+        return 1
+    fi
+    
+    echo -e "${GREEN}✓ Branch naming correct: $current_branch${NC}"
+    return 0
+}
+
+# Function to check for uncommitted changes
+check_uncommitted_changes() {
+    if ! git diff-index --quiet HEAD --; then
+        echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
+        echo -e "   Commit or stash changes before pushing"
+        return 1
+    fi
+    return 0
+}
+
+# Function to check PR exists
+check_pr_exists() {
+    if ! command -v gh &> /dev/null; then
+        echo -e "${YELLOW}⚠️  GitHub CLI not available, skipping PR checks${NC}"
+        return 0
+    fi
+    
+    local current_branch=$(git branch --show-current)
+    local pr_number=$(gh pr list --head "$current_branch" --json number --jq '.[0].number' 2>/dev/null || echo "")
+    
+    if [ -z "$pr_number" ]; then
+        echo -e "${YELLOW}⚠️  No PR found for branch: $current_branch${NC}"
+        echo -e "   Create a PR first: gh pr create"
+        return 1
+    fi
+    
+    echo -e "${GREEN}✓ PR #$pr_number exists for branch${NC}"
+    
+    # Check PR status
+    check_pr_status "$pr_number"
+    return $?
+}
+
+# Function to check PR status
+check_pr_status() {
+    local pr_number=$1
+    local violations=0
+    
+    # Get PR data
+    local pr_data=$(gh pr view "$pr_number" --json isDraft,mergeable,reviews,comments 2>/dev/null || echo "{}")
+    
+    if [ "$pr_data" == "{}" ]; then
+        echo -e "${RED}❌ Failed to fetch PR data${NC}"
+        return 1
+    fi
+    
+    # Check if PR is draft
+    local is_draft=$(echo "$pr_data" | jq -r '.isDraft')
+    if [ "$is_draft" == "true" ]; then
+        echo -e "${YELLOW}⚠️  PR is still in draft mode${NC}"
+        violations=$((violations + 1))
+    fi
+    
+    # Check for unresolved comments
+    local comment_count=$(echo "$pr_data" | jq '.comments | length')
+    if [ "$comment_count" -gt 0 ]; then
+        echo -e "${YELLOW}⚠️  PR has $comment_count comments - ensure all are addressed${NC}"
+    fi
+    
+    # Check mergeable status
+    local mergeable=$(echo "$pr_data" | jq -r '.mergeable')
+    if [ "$mergeable" == "CONFLICTING" ]; then
+        echo -e "${RED}❌ PR has merge conflicts${NC}"
+        violations=$((violations + 1))
+    fi
+    
+    return $violations
+}
+
+# Function to check issue reference
+check_issue_reference() {
+    local current_branch=$(git branch --show-current)
+    
+    # Extract issue number from branch name
+    if [[ "$current_branch" =~ issue-([0-9]+) ]]; then
+        local issue_number="${BASH_REMATCH[1]}"
+        echo -e "${GREEN}✓ Issue reference found: #$issue_number${NC}"
+        
+        # Check if issue exists and is open
+        if command -v gh &> /dev/null; then
+            local issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null || echo "")
+            
+            if [ -z "$issue_state" ]; then
+                echo -e "${YELLOW}⚠️  Could not verify issue #$issue_number${NC}"
+            elif [ "$issue_state" != "OPEN" ]; then
+                echo -e "${YELLOW}⚠️  Issue #$issue_number is $issue_state${NC}"
+            else
+                echo -e "${GREEN}✓ Issue #$issue_number is OPEN${NC}"
+            fi
+        fi
+        
+        return 0
+    else
+        echo -e "${RED}❌ No issue reference in branch name${NC}"
+        return 1
+    fi
+}
+
+# Main enforcement logic
+main() {
+    local total_violations=0
+    
+    echo -e "${BLUE}==== PR Workflow Enforcement ====${NC}"
+    
+    # Run all checks
+    check_git_repo || exit 1
+    
+    check_branch_naming || total_violations=$((total_violations + 1))
+    check_uncommitted_changes || total_violations=$((total_violations + 1))
+    check_issue_reference || total_violations=$((total_violations + 1))
+    check_pr_exists || total_violations=$((total_violations + 1))
+    
+    echo -e "${BLUE}=================================${NC}"
+    
+    # Summary
+    if [ $total_violations -eq 0 ]; then
+        echo -e "${GREEN}✅ All workflow rules passed!${NC}"
+        exit 0
+    else
+        echo -e "${RED}❌ Found $total_violations workflow violations${NC}"
+        echo -e "${YELLOW}Fix the issues above before pushing${NC}"
+        echo -e "${YELLOW}Or use 'git push --no-verify' to skip checks${NC}"
+        exit 1
+    fi
+}
+
+# Run main function
+main

--- a/docs/HOOK-ALIGNMENT-ANALYSIS.md
+++ b/docs/HOOK-ALIGNMENT-ANALYSIS.md
@@ -1,0 +1,140 @@
+# Hook Alignment Analysis for vibe-codex
+
+## Overview
+
+This document analyzes the current state of hooks in the vibe-codex project and proposes alignment with the project's intended functionality as a simple npx tool for installing development rules and git hooks.
+
+## Current Hook State
+
+### 1. **Active Git Hooks** (in .git/hooks/)
+- `pre-commit`: Runs pr-health-check.sh and security-pre-commit.sh
+- `commit-msg`: Validates commit messages
+- `post-commit`: References missing continuous-pr-monitor.sh
+- `post-merge`: Branch cleanup automation
+- `pre-push`: References missing enforce-pr-workflow.sh
+
+### 2. **Development Scripts** (in /hooks/)
+Contains 20+ hook scripts including:
+- Workflow enforcement hooks
+- Issue management hooks
+- PR review hooks
+- Testing and quality hooks
+- Installation utilities
+
+### 3. **Claude-Specific Hooks** (in /.claude/hooks/)
+Contains specialized hooks for Claude integration but missing referenced scripts.
+
+### 4. **NPX Tool Hooks** (vibe-codex/lib/installer/git-hooks.js)
+The actual product installs:
+- `pre-commit`: Always installed, runs validation
+- `commit-msg`: Conditional, validates commit format
+- `pre-push`: Conditional, runs tests and PR checks
+- `post-commit`: Conditional, tracks issue progress
+
+### 5. **Module Hook Directories** (Empty)
+Prepared for modular architecture but unused.
+
+## Alignment Issues
+
+### 1. **Missing Referenced Scripts**
+- `.claude/hooks/continuous-pr-monitor.sh` (referenced by post-commit)
+- `.claude/hooks/enforce-pr-workflow.sh` (referenced by pre-push)
+
+### 2. **Inconsistent Implementation**
+- Development hooks in /hooks/ are complex bash scripts
+- NPX tool generates simple wrapper scripts
+- Module directories prepared but empty
+
+### 3. **Scope Creep**
+- Many hooks implement features beyond core functionality
+- Complex workflow enforcement vs simple rule checking
+- Development-specific hooks mixed with user-facing hooks
+
+## Proposed Alignment
+
+### Core Product Hooks (NPX vibe-codex)
+
+Based on the simplified vision (#212), vibe-codex should install only:
+
+#### 1. **pre-commit**
+```bash
+#!/bin/sh
+# Check for rule violations
+# Run security checks
+# Validate file formatting
+```
+
+#### 2. **commit-msg**
+```bash
+#!/bin/sh
+# Validate conventional commit format
+# Ensure issue references
+```
+
+#### 3. **pre-push** (optional)
+```bash
+#!/bin/sh
+# Run tests if configured
+# Check PR status if GitHub integration enabled
+```
+
+### Development Hooks (This Repository)
+
+Keep separate from product:
+
+#### 1. **Workflow Enforcement**
+- PR health checks
+- Issue tracking
+- Branch management
+
+#### 2. **Claude Integration**
+- Context monitoring
+- PR workflow enforcement
+- Automated updates
+
+## Recommended Actions
+
+### 1. **Immediate Fixes**
+- Remove broken hook references in .git/hooks/
+- Create missing Claude hooks or update references
+- Clean up stale development hooks
+
+### 2. **Product Clarification**
+- Move complex hooks to development-only directory
+- Simplify NPX tool to install only essential hooks
+- Document which hooks are for development vs users
+
+### 3. **Module Integration**
+- Populate module hook directories with appropriate scripts
+- Create clear separation between core and optional hooks
+- Implement hook discovery mechanism
+
+### 4. **Documentation**
+- Create user guide for hook installation
+- Document development workflow hooks separately
+- Provide customization examples
+
+## Hook Categories
+
+### Essential (Core Product)
+1. `pre-commit` - Basic validation
+2. `commit-msg` - Message format
+
+### Optional (Modules)
+1. `pre-push` - Testing module
+2. `post-commit` - GitHub module
+3. `prepare-commit-msg` - Templates module
+
+### Development Only
+1. Issue tracking hooks
+2. PR workflow enforcement
+3. Claude integration hooks
+4. Branch cleanup automation
+
+## Next Steps
+
+1. Create issue to fix broken hook references
+2. Create issue to simplify product hooks
+3. Create issue to reorganize hook directories
+4. Create issue to document hook system
+5. Update existing transformation issues to reflect hook simplification


### PR DESCRIPTION
## Summary

This PR fixes the broken git hook references by creating the missing Claude hook scripts.

## Problem
- `.git/hooks/post-commit` referenced missing `.claude/hooks/continuous-pr-monitor.sh`
- `.git/hooks/pre-push` referenced missing `.claude/hooks/enforce-pr-workflow.sh`

## Solution

### Created continuous-pr-monitor.sh
- Monitors PR status after each commit
- Checks mergeable state and review status
- Automatically enables auto-merge when PR is ready
- Provides helpful status information

### Created enforce-pr-workflow.sh
- Validates branch naming conventions
- Checks for uncommitted changes
- Ensures PR exists before pushing
- Verifies issue references
- Provides clear feedback on violations

## Testing
Both scripts have been tested and work correctly:
- The enforce script caught the missing PR and provided guidance
- The monitor script properly checks PR status
- Both scripts handle missing dependencies gracefully

## Additional Changes
- Created HOOK-ALIGNMENT-ANALYSIS.md documenting the current hook state
- Made both scripts executable

Fixes #228