### PR TITLE
Add pre-push conflict detection rule

### DIFF
--- a/rules/registry.json
+++ b/rules/registry.json
@@ -211,6 +211,17 @@
       "performance_impact": "low"
     },
     {
+      "id": "wfl-006",
+      "name": "Pre-Push Conflict Detection",
+      "category": "workflow",
+      "complexity": "basic",
+      "enabled_by_default": true,
+      "description": "Detect merge conflicts before pushing to prevent unmergeable PRs",
+      "file": "/rules/workflow/pre-push-conflict-detection.md#rule-wfl-006-pre-push-conflict-detection",
+      "implementation": "pre-push",
+      "performance_impact": "low"
+    },
+    {
       "id": "ai-001",
       "name": "Project Context Alignment",
       "category": "ai-development",
@@ -379,7 +390,7 @@
     "standard": {
       "name": "Standard",
       "description": "Recommended rules for most projects",
-      "rules": ["sec-001", "sec-002", "sec-003", "cmt-001", "tst-003", "doc-001", "sty-001", "sty-002"]
+      "rules": ["sec-001", "sec-002", "sec-003", "cmt-001", "tst-003", "doc-001", "sty-001", "sty-002", "wfl-006"]
     },
     "strict": {
       "name": "Strict",
@@ -389,7 +400,7 @@
     "ai-developer": {
       "name": "AI Developer",
       "description": "Optimized for AI-assisted development",
-      "rules": ["sec-001", "sec-002", "sec-003", "cmt-001", "cmt-002", "ai-001", "ai-003", "wfl-001", "wfl-002"]
+      "rules": ["sec-001", "sec-002", "sec-003", "cmt-001", "cmt-002", "ai-001", "ai-003", "wfl-001", "wfl-002", "wfl-006"]
     },
     "enterprise": {
       "name": "Enterprise",

--- a/rules/workflow/pre-push-conflict-detection.md
+++ b/rules/workflow/pre-push-conflict-detection.md
@@ -1,0 +1,124 @@
+# RULE-WFL-006: Pre-Push Conflict Detection
+
+**Category**: Workflow  
+**Complexity**: Basic  
+**Default**: Enabled  
+**Hook Type**: Pre-push  
+**Performance Impact**: Low  
+
+## Purpose
+
+Detect merge conflicts BEFORE pushing to remote repositories to:
+- Prevent creating PRs that cannot be merged
+- Save CI/CD resources
+- Reduce review friction
+- Maintain clean PR history
+
+## Problem It Solves
+
+Without this rule:
+1. Developer pushes branch with conflicts
+2. Creates PR
+3. CI runs (wasting resources)
+4. Review starts
+5. Then discovers PR can't be merged
+6. Must go back and resolve conflicts
+7. Force push breaks review history
+
+With this rule:
+1. Developer attempts to push
+2. Conflicts detected locally
+3. Must resolve before pushing
+4. PR is always mergeable
+
+## Implementation
+
+### Hook Behavior
+```bash
+# Pre-push hook runs before git push
+# Checks current branch against target (main/preview)
+# Performs dry-run merge to detect conflicts
+# Blocks push if conflicts found
+```
+
+### Conflict Detection Method
+1. Fetches latest target branch
+2. Finds merge base
+3. Uses `git merge-tree` for dry-run merge
+4. Checks for conflict markers
+5. Provides clear resolution instructions
+
+## Configuration
+
+### Enable in .vibe-codex.json
+```json
+{
+  "rules": {
+    "workflow": {
+      "pre-push-conflict-detection": {
+        "enabled": true,
+        "options": {
+          "target_branch": "preview",
+          "strict_mode": false,
+          "check_all_remotes": false
+        }
+      }
+    }
+  }
+}
+```
+
+### Options
+- **target_branch**: Default branch to check against (preview/main)
+- **strict_mode**: Also check for non-conflict merge issues
+- **check_all_remotes**: Check conflicts for all configured remotes
+
+## Benefits
+
+1. **Early Detection**: Find conflicts before they reach CI/CD
+2. **Resource Saving**: No wasted builds on unmergeable code
+3. **Better Reviews**: PRs always start in mergeable state
+4. **Clear History**: No force-push confusion during reviews
+
+## Example Output
+
+### Success Case
+```
+🔍 Checking for conflicts with target branch...
+Fetching latest preview from origin...
+Checking for conflicts with preview...
+✅ No conflicts detected with preview
+```
+
+### Conflict Detected
+```
+🔍 Checking for conflicts with target branch...
+Fetching latest preview from origin...
+Checking for conflicts with preview...
+
+❌ ERROR: Merge conflicts detected with preview!
+
+Your branch has conflicts that must be resolved before pushing.
+This prevents creating PRs that cannot be merged.
+
+To fix:
+  1. git fetch origin preview
+  2. git merge origin/preview
+  3. Resolve conflicts
+  4. git add <resolved files>
+  5. git commit
+  6. git push
+```
+
+## Bypass (Emergency Only)
+
+If you absolutely must push with conflicts:
+```bash
+git push --no-verify
+```
+
+⚠️ **Warning**: This creates unmergeable PRs and should be avoided.
+
+## Related Rules
+- RULE-WFL-002: PR Workflow Enforcement
+- RULE-WFL-001: Issue-Driven Development

--- a/templates/hooks/pre-push-conflict-check.sh
+++ b/templates/hooks/pre-push-conflict-check.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# vibe-codex pre-push conflict detection hook
+# Checks for merge conflicts before pushing to prevent unmergeable PRs
+
+echo "🔍 Checking for conflicts with target branch..."
+
+# Get the remote and branch being pushed to
+remote="$1"
+url="$2"
+
+# Read the branches being pushed
+while read local_ref local_sha remote_ref remote_sha; do
+  # Skip if deleting a branch
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue
+  fi
+  
+  # Extract branch names
+  local_branch="${local_ref#refs/heads/}"
+  remote_branch="${remote_ref#refs/heads/}"
+  
+  # Determine target branch (usually main or preview)
+  target_branch="preview"  # Default to preview
+  
+  # Check if main branch exists on remote
+  if git ls-remote --heads "$remote" main | grep -q "refs/heads/main"; then
+    # If we're not pushing to main, check against main
+    if [ "$remote_branch" != "main" ]; then
+      target_branch="main"
+    fi
+  fi
+  
+  # Fetch latest target branch
+  echo "Fetching latest $target_branch from $remote..."
+  git fetch "$remote" "$target_branch" --quiet
+  
+  # Check for conflicts
+  echo "Checking for conflicts with $target_branch..."
+  
+  # Find merge base
+  merge_base=$(git merge-base HEAD "$remote/$target_branch")
+  
+  # Attempt a test merge (dry run)
+  if ! git merge-tree "$merge_base" HEAD "$remote/$target_branch" 2>&1 | grep -q '<<<<<<<'; then
+    echo "✅ No conflicts detected with $target_branch"
+  else
+    echo ""
+    echo "❌ ERROR: Merge conflicts detected with $target_branch!"
+    echo ""
+    echo "Your branch has conflicts that must be resolved before pushing."
+    echo "This prevents creating PRs that cannot be merged."
+    echo ""
+    echo "To fix:"
+    echo "  1. git fetch $remote $target_branch"
+    echo "  2. git merge $remote/$target_branch"
+    echo "  3. Resolve conflicts"
+    echo "  4. git add <resolved files>"
+    echo "  5. git commit"
+    echo "  6. git push"
+    echo ""
+    echo "Or rebase:"
+    echo "  1. git fetch $remote $target_branch"
+    echo "  2. git rebase $remote/$target_branch"
+    echo "  3. Resolve conflicts if any"
+    echo "  4. git push --force-with-lease"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a pre-push hook that detects merge conflicts before pushing, preventing the creation of unmergeable PRs.

## Changes

### New Rule: WFL-006 - Pre-Push Conflict Detection
- Created `/rules/workflow/pre-push-conflict-detection.md`
- Detects conflicts with target branch (main/preview)
- Blocks push if conflicts found
- Provides clear resolution instructions

### Hook Implementation
- Added `templates/hooks/pre-push-conflict-check.sh`
- Uses `git merge-tree` for efficient conflict detection
- Fetches latest target branch before checking
- Non-invasive (dry-run only)

### Registry Update
- Added WFL-006 to `rules/registry.json`
- Enabled by default in standard and ai-developer presets
- Category: workflow
- Complexity: basic

## Benefits

1. **Early Detection**: Find conflicts before they reach CI/CD
2. **Resource Saving**: No wasted builds on unmergeable code
3. **Better Reviews**: PRs always start in mergeable state
4. **Clear History**: No force-push confusion during reviews

## Example Output

When conflicts are detected:
```
❌ ERROR: Merge conflicts detected with preview\!

Your branch has conflicts that must be resolved before pushing.
This prevents creating PRs that cannot be merged.

To fix:
  1. git fetch origin preview
  2. git merge origin/preview
  3. Resolve conflicts
  4. git add <resolved files>
  5. git commit
  6. git push
```

## Testing

- [x] Hook script tested with conflict scenarios
- [x] Registry entry validates
- [x] No conflicts with preview branch

Implements #254