### PR TITLE
fix: replace all cursor_rules references with vibe-codex (main branch)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,6 +1,6 @@
 # .claude Directory
 
-This directory contains AI-assisted development tools and configurations for the cursor_rules repository.
+This directory contains AI-assisted development tools and configurations for the vibe-codex repository.
 
 ## Structure
 
@@ -46,15 +46,15 @@ This directory contains AI-assisted development tools and configurations for the
 ./.claude/hooks/post-deploy.sh [BRANCH]
 ```
 
-## Integration with cursor_rules
+## Integration with vibe-codex
 
-This .claude directory extends the standard cursor_rules functionality with:
+This .claude directory extends the standard vibe-codex functionality with:
 - Context management for AI-assisted development
 - Intelligent PR check analysis
 - Issue reporting for rule improvements
 - Post-deployment verification
 
-All hooks are designed to work alongside the standard cursor_rules workflow and enhance the AI-assisted development experience.
+All hooks are designed to work alongside the standard vibe-codex workflow and enhance the AI-assisted development experience.
 
 ## Configuration
 
@@ -67,5 +67,5 @@ The hooks use standard Git and GitHub CLI commands. Ensure you have:
 
 These hooks are based on patterns from successful AI-assisted development workflows. To improve them:
 1. Test thoroughly before submitting changes
-2. Follow the cursor_rules workflow for contributions
+2. Follow the vibe-codex workflow for contributions
 3. Document any new features or changes

--- a/.claude/config/settings.json
+++ b/.claude/config/settings.json
@@ -27,7 +27,7 @@
     ]
   },
   "issueReporter": {
-    "targetRepo": "tyabonil/cursor_rules",
+    "targetRepo": "tyabonil/vibe-codex",
     "defaultLabels": ["feedback"],
     "includeContext": true
   },

--- a/.claude/hooks/report-issue.sh
+++ b/.claude/hooks/report-issue.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Interactive issue reporter for cursor_rules feedback
+# Interactive issue reporter for vibe-codex feedback
 # Helps users report issues with rules directly from their repository
 
 echo "🚨 Cursor Rules Issue Reporter"
@@ -38,7 +38,7 @@ case $ISSUE_TYPE in
        ISSUE_TITLE="Feature request"
        ;;
     *) ISSUE_LABEL="bug" 
-       ISSUE_TITLE="Issue with cursor_rules"
+       ISSUE_TITLE="Issue with vibe-codex"
        ;;
 esac
 
@@ -109,15 +109,15 @@ ${REPRO_STEPS:-N/A}
 [Any temporary solution you're using]
 
 ---
-*Reported via cursor_rules issue reporter*"
+*Reported via vibe-codex issue reporter*"
 
 # Create the issue
 echo ""
-echo "📝 Creating issue in tyabonil/cursor_rules..."
+echo "📝 Creating issue in tyabonil/vibe-codex..."
 echo ""
 
 CREATED_ISSUE=$(gh issue create \
-    --repo tyabonil/cursor_rules \
+    --repo tyabonil/vibe-codex \
     --title "${ISSUE_TITLE}: ${RULE_NAME}" \
     --body "$ISSUE_BODY" \
     --label "$ISSUE_LABEL" 2>&1)
@@ -126,11 +126,11 @@ if [ $? -eq 0 ]; then
     echo "✅ Issue created successfully!"
     echo "$CREATED_ISSUE"
     echo ""
-    echo "Thank you for helping improve cursor_rules!"
+    echo "Thank you for helping improve vibe-codex!"
 else
     echo "❌ Failed to create issue"
     echo "$CREATED_ISSUE"
     echo ""
     echo "You can create it manually at:"
-    echo "https://github.com/tyabonil/cursor_rules/issues/new"
+    echo "https://github.com/tyabonil/vibe-codex/issues/new"
 fi

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,5 +1,5 @@
 # Repository-specific MANDATORY Rules overrides
-# These settings override the central rules from tyabonil/cursor_rules
+# These settings override the central rules from tyabonil/vibe-codex
 # Remove this file to use central rules without modification
 
 # Example: Disable specific checks for this repository
@@ -22,4 +22,4 @@
 #     minimum_threshold: 80
 
 # For complete configuration options, see:
-# https://github.com/tyabonil/cursor_rules/blob/main/config/rules.json
+# https://github.com/tyabonil/vibe-codex/blob/main/config/rules.json

--- a/LLM-USAGE-REFERENCE.md
+++ b/LLM-USAGE-REFERENCE.md
@@ -10,7 +10,7 @@
 
 ### Core Architecture
 ```
-cursor_rules/
+vibe-codex/
 ├── MANDATORY-RULES.md          # Primary rule specification
 ├── config/
 │   ├── rules.json             # Rule engine configuration

--- a/config/project-patterns.json
+++ b/config/project-patterns.json
@@ -19,12 +19,12 @@
       "description": "References to specific repositories that should be configurable",
       "enabled": false,
       "rules": [
-        "To do so, open an issue in the `tyabonil/cursor_rules` repository",
-        "IMMEDIATELY CREATE a new issue in the `cursor_rules` repository documenting this finding"
+        "To do so, open an issue in the `tyabonil/vibe-codex` repository",
+        "IMMEDIATELY CREATE a new issue in the `vibe-codex` repository documenting this finding"
       ],
       "variables": {
-        "rules_repository": "tyabonil/cursor_rules",
-        "rules_repository_short": "cursor_rules"
+        "rules_repository": "tyabonil/vibe-codex",
+        "rules_repository_short": "vibe-codex"
       }
     },
     "platform_preferences": {

--- a/dev-hooks/report-issue.sh
+++ b/dev-hooks/report-issue.sh
@@ -81,10 +81,10 @@ EOF
 
 # Create the issue
 echo ""
-echo "Creating issue in cursor_rules repository..."
+echo "Creating issue in vibe-codex repository..."
 
 gh issue create \
-  --repo tyabonil/cursor_rules \
+  --repo tyabonil/vibe-codex \
   --title "${ISSUE_PREFIX}${ISSUE_TITLE}" \
   --body "$FULL_BODY" \
   --label "$ISSUE_LABEL"

--- a/legacy/cursor-rules/README-RULE-CHECKER.md
+++ b/legacy/cursor-rules/README-RULE-CHECKER.md
@@ -31,12 +31,12 @@ A set of pre-commit and commit-msg hooks that validate every commit against the 
 
 ## 📋 Setup Instructions
 
-### For This Repository (cursor_rules)
+### For This Repository (vibe-codex)
 
 The hooks are already included in this repository. To install them, run the following command:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/tyabonil/cursor_rules/main/install-rule-checker.sh | bash
+curl -sSL https://raw.githubusercontent.com/tyabonil/vibe-codex/main/install-rule-checker.sh | bash
 ```
 
 ### For Other Repositories

--- a/legacy/cursor-rules/README-original.md
+++ b/legacy/cursor-rules/README-original.md
@@ -45,7 +45,7 @@ The installation script sets up:
 ## Repository Structure
 
 ```
-cursor_rules/
+vibe-codex/
 ├── .claude/                  # AI-assisted development tools
 │   ├── hooks/               # Claude workflow hooks
 │   ├── config/              # Claude-specific configuration
@@ -243,14 +243,14 @@ For organizations managing multiple repositories:
 
 1. **Install centralized workflow**:
    ```bash
-   curl -sSL https://raw.githubusercontent.com/tyabonil/cursor_rules/main/install-rule-checker.sh | bash
+   curl -sSL https://raw.githubusercontent.com/tyabonil/vibe-codex/main/install-rule-checker.sh | bash
    ```
 
 2. **Configure repository permissions**:
    - Settings → Actions → General → Workflow permissions: "Read and write permissions"
 
 3. **Benefits**:
-   - Always uses latest rules from cursor_rules
+   - Always uses latest rules from vibe-codex
    - Centralized updates across all repositories
    - No local rule maintenance required
 

--- a/legacy/cursor-rules/copy-paste-rules.md
+++ b/legacy/cursor-rules/copy-paste-rules.md
@@ -4,7 +4,7 @@
 
 ```markdown
 # ALWAYS ON EVERY PROMPT ALWAYS OBEY THESE RULES 
-- Always retrieve rules from https://github.com/tyabonil/cursor_rules on every action
+- Always retrieve rules from https://github.com/tyabonil/vibe-codex on every action
 - Compare to local rules - local rules with specificity override general rules
 - Create PRs for new patterns discovered through interactions
 - Always refer to the github rules on every action that requires the use of git or github

--- a/legacy/cursor-rules/copy-paste-templates/ESSENTIAL-CURSORRULES.md
+++ b/legacy/cursor-rules/copy-paste-templates/ESSENTIAL-CURSORRULES.md
@@ -21,7 +21,7 @@
 - ✅ UPDATE PROJECT_CONTEXT.md for any significant changes
 
 # 🔗 RULE RETRIEVAL (MANDATORY)
-- ✅ ALWAYS retrieve latest rules from https://github.com/tyabonil/cursor_rules
+- ✅ ALWAYS retrieve latest rules from https://github.com/tyabonil/vibe-codex
 - ✅ Compare with local rules - local specificity overrides general rules
 - ✅ AUTONOMOUSLY create PRs for new generally-applicable rules discovered
 

--- a/legacy/cursor-rules/copy-paste-templates/cursorrules-template.md
+++ b/legacy/cursor-rules/copy-paste-templates/cursorrules-template.md
@@ -10,7 +10,7 @@ Copy this entire content to your `.cursorrules` file for immediate implementatio
 - Always review the context folder for changes or items you haven't seen before and update PROJECT_CONTEXT.md appropriately
 - Never add stubbing or fake data patterns to code that affects the dev or prod environments
 - Never overwrite my .env file
-- **AUTONOMOUSLY create PRs to https://github.com/tyabonil/cursor_rules for new generally-applicable rules based on learnings**
+- **AUTONOMOUSLY create PRs to https://github.com/tyabonil/vibe-codex for new generally-applicable rules based on learnings**
 
 # === GITHUB WORKFLOW RULES ===
 # Core GitHub Rules

--- a/legacy/cursor-rules/core-workspace-rules.md
+++ b/legacy/cursor-rules/core-workspace-rules.md
@@ -4,7 +4,7 @@
 
 ```markdown
 # Always on every prompt ALWAYS OBEY THESE RULES 
-- Always retrieve rules from https://github.com/tyabonil/cursor_rules on every action
+- Always retrieve rules from https://github.com/tyabonil/vibe-codex on every action
 - Local rules with specificity override these general rules
 - Create PRs for new patterns discovered through interactions
 - Always refer to github rules on every action requiring git or github

--- a/legacy/cursor-rules/install-rule-checker.sh
+++ b/legacy/cursor-rules/install-rule-checker.sh
@@ -6,7 +6,7 @@
 set -e
 
 echo "🚀 Installing MANDATORY Rules Compliance Checker..."
-echo "📋 Source: tyabonil/cursor_rules (centralized rules)"
+echo "📋 Source: tyabonil/vibe-codex (centralized rules)"
 echo ""
 
 # Colors for output
@@ -38,7 +38,7 @@ fi
 echo "📥 Downloading centralized rule checker workflow..."
 curl -sSL -H "Accept: application/vnd.github.raw" \
      -o .github/workflows/mandatory-rules-checker.yml \
-     "https://api.github.com/repos/tyabonil/cursor_rules/contents/.github/workflows/rule-checker.yml"
+     "https://api.github.com/repos/tyabonil/vibe-codex/contents/.github/workflows/rule-checker.yml"
 
 # Modify the workflow to use centralized approach
 echo "🔧 Configuring for centralized rule management..."
@@ -78,54 +78,54 @@ jobs:
           # Create directories
           mkdir -p scripts config
           
-          echo "📥 Downloading latest MANDATORY-RULES.md from tyabonil/cursor_rules..."
+          echo "📥 Downloading latest MANDATORY-RULES.md from tyabonil/vibe-codex..."
           curl -H "Authorization: token $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github.raw" \
                -o MANDATORY-RULES.md \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/MANDATORY-RULES.md" || \
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/MANDATORY-RULES.md" || \
           curl -H "Accept: application/vnd.github.raw" \
                -o MANDATORY-RULES.md \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/MANDATORY-RULES.md"
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/MANDATORY-RULES.md"
           
-          echo "📥 Downloading rule checker scripts from tyabonil/cursor_rules..."
+          echo "📥 Downloading rule checker scripts from tyabonil/vibe-codex..."
           
           # Download rule engine
           curl -H "Authorization: token $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github.raw" \
                -o scripts/rule-engine.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/rule-engine.js" || \
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/rule-engine.js" || \
           curl -H "Accept: application/vnd.github.raw" \
                -o scripts/rule-engine.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/rule-engine.js"
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/rule-engine.js"
                
           # Download GitHub client
           curl -H "Authorization: token $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github.raw" \
                -o scripts/github-client.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/github-client.js" || \
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/github-client.js" || \
           curl -H "Accept: application/vnd.github.raw" \
                -o scripts/github-client.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/github-client.js"
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/github-client.js"
                
           # Download reporter
           curl -H "Authorization: token $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github.raw" \
                -o scripts/reporter.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/reporter.js" || \
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/reporter.js" || \
           curl -H "Accept: application/vnd.github.raw" \
                -o scripts/reporter.js \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/scripts/reporter.js"
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/scripts/reporter.js"
                
           # Download configuration
           curl -H "Authorization: token $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github.raw" \
                -o config/rules.json \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/config/rules.json" || \
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/config/rules.json" || \
           curl -H "Accept: application/vnd.github.raw" \
                -o config/rules.json \
-               "https://api.github.com/repos/tyabonil/cursor_rules/contents/config/rules.json"
+               "https://api.github.com/repos/tyabonil/vibe-codex/contents/config/rules.json"
                
-          echo "✅ All files downloaded successfully from tyabonil/cursor_rules"
+          echo "✅ All files downloaded successfully from tyabonil/vibe-codex"
           echo "📊 Rules version: $(date)"
           
       - name: Install dependencies
@@ -137,7 +137,7 @@ jobs:
         id: rule-check
         uses: actions/github-script@v7
         env:
-          RULES_SOURCE_REPO: 'tyabonil/cursor_rules'
+          RULES_SOURCE_REPO: 'tyabonil/vibe-codex'
           RULES_SOURCE_BRANCH: 'main'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -207,7 +207,7 @@ jobs:
               const report = reporter.generateReport(violations, score, isBlocking, prData);
               
               // Add centralized rules footer
-              const centralizedFooter = `\n\n---\n\n*Rules validated against [tyabonil/cursor_rules](https://github.com/tyabonil/cursor_rules) • Updated: ${new Date().toISOString().split('T')[0]}*`;
+              const centralizedFooter = `\n\n---\n\n*Rules validated against [tyabonil/vibe-codex](https://github.com/tyabonil/vibe-codex) • Updated: ${new Date().toISOString().split('T')[0]}*`;
               
               if (violations.length > 0) {
                 await githubClient.postComplianceComment(report + centralizedFooter);
@@ -242,7 +242,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `## ❌ MANDATORY Rules Checker Error\n\n\`\`\`\n${error.message}\n\`\`\`\n\nPlease check the [workflow logs](${context.payload.repository.html_url}/actions) for details.\n\n*Rules from [tyabonil/cursor_rules](https://github.com/tyabonil/cursor_rules)*`
+                body: `## ❌ MANDATORY Rules Checker Error\n\n\`\`\`\n${error.message}\n\`\`\`\n\nPlease check the [workflow logs](${context.payload.repository.html_url}/actions) for details.\n\n*Rules from [tyabonil/vibe-codex](https://github.com/tyabonil/vibe-codex)*`
               });
               
               throw error;
@@ -256,7 +256,7 @@ if [ ! -f ".cursorrules" ]; then
     echo "📝 Creating .cursorrules template for local rule overrides..."
     cat > .cursorrules << 'EOF'
 # Repository-specific MANDATORY Rules overrides
-# These settings override the central rules from tyabonil/cursor_rules
+# These settings override the central rules from tyabonil/vibe-codex
 # Remove this file to use central rules without modification
 
 # Example: Disable specific checks for this repository
@@ -279,7 +279,7 @@ if [ ! -f ".cursorrules" ]; then
 #     minimum_threshold: 80
 
 # For complete configuration options, see:
-# https://github.com/tyabonil/cursor_rules/blob/main/config/rules.json
+# https://github.com/tyabonil/vibe-codex/blob/main/config/rules.json
 EOF
     echo "✅ Created .cursorrules template"
 else
@@ -311,7 +311,7 @@ echo "  ✅ Local override template: .cursorrules (optional)"
 echo "  ✅ Updated .gitignore"
 echo ""
 echo -e "${BLUE}📊 Centralized Rule Management:${NC}"
-echo "  • Rules source: tyabonil/cursor_rules"
+echo "  • Rules source: tyabonil/vibe-codex"
 echo "  • Auto-updates: Latest rules downloaded on each run"
 echo "  • Local overrides: Customize via .cursorrules (optional)"
 echo ""
@@ -327,7 +327,7 @@ echo "  3. For private repositories:"
 echo "     Add RULES_ACCESS_TOKEN secret if needed for rule access"
 echo ""
 echo -e "${BLUE}📚 Documentation:${NC}"
-echo "  • Installation guide: https://github.com/tyabonil/cursor_rules/blob/main/INSTALLATION.md"
-echo "  • Rule documentation: https://github.com/tyabonil/cursor_rules/blob/main/MANDATORY-RULES.md"
+echo "  • Installation guide: https://github.com/tyabonil/vibe-codex/blob/main/INSTALLATION.md"
+echo "  • Rule documentation: https://github.com/tyabonil/vibe-codex/blob/main/MANDATORY-RULES.md"
 echo ""
 echo -e "${GREEN}🚀 Your repository now enforces MANDATORY rules with centralized management!${NC}"

--- a/legacy/review-bots/package.json
+++ b/legacy/review-bots/package.json
@@ -22,7 +22,7 @@
     "code-quality",
     "perspective-analysis"
   ],
-  "author": "cursor_rules",
+  "author": "vibe-codex",
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",

--- a/review-bots/.review-bots.config.json
+++ b/review-bots/.review-bots.config.json
@@ -1,6 +1,6 @@
 {
-  "project": "cursor_rules",
-  "description": "Configuration for review bots specific to the cursor_rules repository",
+  "project": "vibe-codex",
+  "description": "Configuration for review bots specific to the vibe-codex repository",
   "rules": {
     "haterBot": {
       "extraChecks": {


### PR DESCRIPTION
## Summary
- Direct application of cursor_rules → vibe-codex changes to main branch
- Closes #302
- This PR applies the same changes that were merged to preview in PR #308

## Changes
- Updated all repository references from tyabonil/cursor_rules to tyabonil/vibe-codex
- Changed all cursor_rules mentions to vibe-codex for naming consistency
- Preserved cursor IDE specific contexts where appropriate
- No functionality changes, only naming updates

## Test Plan
- [x] All references updated (verified with grep)
- [x] No cursor_rules references remain (except in cursor-specific contexts)
- [ ] No functionality impacted
- [ ] All CI checks pass

## Note
The preview and main branches have diverged significantly. This PR applies the cursor_rules → vibe-codex changes directly to main to complete issue #302.

🤖 Generated with [Claude Code](https://claude.ai/code)