### PR TITLE
fix: remove npm cache from review-bots workflow

### DIFF
--- a/.github/workflows/review-bots.yml
+++ b/.github/workflows/review-bots.yml
@@ -26,8 +26,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: legacy/review-bots/package.json
     
     - name: Install Review Bots
       run: |


### PR DESCRIPTION
The cache-dependency-path was pointing to legacy/review-bots/package.json which doesn't exist in branches that remove the legacy code, causing CI failures.

This PR removes the npm cache configuration from the review-bots workflow to fix the CI error.

## Error fixed
```
Setup Node.js step error:
Some specified paths were not resolved, unable to cache dependencies.
```

## Solution
Removed the cache configuration entirely since the legacy/review-bots directory may not exist in all branches.