### PR TITLE
fix: remove project-specific implementations

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,65 @@
+# Vibe Codex Configuration
+
+## Environment Variables
+
+Vibe Codex can be configured using environment variables to customize repository URLs and other settings:
+
+### Repository Configuration
+
+- `VIBE_CODEX_REPO_URL` - Base URL for downloading rules and templates
+  - Default: `https://raw.githubusercontent.com/your-org/vibe-codex/main`
+  - Example: `VIBE_CODEX_REPO_URL=https://raw.githubusercontent.com/mycompany/our-rules/main`
+
+- `VIBE_CODEX_REPO` - Repository owner/name for GitHub API calls
+  - Default: `your-org/vibe-codex`
+  - Example: `VIBE_CODEX_REPO=mycompany/our-rules`
+
+### Using a Fork or Custom Repository
+
+To use vibe-codex with your own rules repository:
+
+1. Fork the vibe-codex repository
+2. Customize the rules and hooks in your fork
+3. Set the environment variables:
+
+```bash
+export VIBE_CODEX_REPO_URL=https://raw.githubusercontent.com/mycompany/our-rules/main
+export VIBE_CODEX_REPO=mycompany/our-rules
+```
+
+4. Run vibe-codex normally:
+
+```bash
+npx vibe-codex init --type=web --preset
+```
+
+### Configuration File Names
+
+The following file names are used by vibe-codex:
+
+- Configuration: `.vibe-codex.json`
+- Ignore file: `.vibe-codexignore`
+- Work directory: `.vibe-codex/`
+- Backup directory: `.vibe-codex-backup/`
+
+These are currently not configurable but may be in future versions.
+
+## Default Files
+
+The following files are downloaded from the repository:
+
+- `MANDATORY-RULES.md` - Core rules that apply to all projects
+- `PROJECT_CONTEXT.md` - Template for documenting project context
+- `hooks/*` - Git hook scripts
+
+## Customization
+
+To customize vibe-codex for your organization:
+
+1. Fork the repository
+2. Modify the rules in `MANDATORY-RULES.md`
+3. Update hook scripts in the `hooks/` directory
+4. Set the environment variables to point to your fork
+5. Share the configuration with your team
+
+This allows you to maintain organization-specific rules while still benefiting from the vibe-codex framework.

--- a/PROJECT-CONTEXT.md
+++ b/PROJECT-CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Core Purpose (WHY)
 
-vibe-codex exists to help development teams - especially those using AI assistants - maintain code quality, security, and workflow consistency through automated git hooks and development rules. It evolved from cursor_rules, recognizing that AI coding assistants need guardrails to prevent reward hacking, context loss, and deviation from project goals.
+vibe-codex exists to help development teams - especially those using AI assistants - maintain code quality, security, and workflow consistency through automated git hooks and development rules. It recognizes that AI coding assistants need guardrails to prevent reward hacking, context loss, and deviation from project goals.
 
 The project aims to be a comprehensive, menu-driven tool that allows teams to select and configure rules and hooks appropriate to their needs - from simple security checks to complex AI development workflows.
 

--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
 
 ## 📄 License
 
-MIT © Ty Yabonil
+MIT

--- a/docs/ENHANCED-VALIDATION.md
+++ b/docs/ENHANCED-VALIDATION.md
@@ -20,7 +20,7 @@ The Enhanced Pre-commit Validation System provides comprehensive validation to e
 
 ## Installation
 
-The enhanced validation system is automatically included with cursor_rules installation:
+The enhanced validation system is automatically included with vibe-codex installation:
 
 ```bash
 # Standard installation includes enhanced validation

--- a/docs/ISSUE-REMINDERS.md
+++ b/docs/ISSUE-REMINDERS.md
@@ -32,7 +32,7 @@ The system enforces these MANDATORY-RULES.md requirements:
 
 ## Installation
 
-The issue reminder hooks are automatically included when you install cursor_rules:
+The issue reminder hooks are automatically included when you install vibe-codex:
 
 ```bash
 # Standard installation includes issue reminders

--- a/docs/legacy/USAGE-GUIDE.md
+++ b/docs/legacy/USAGE-GUIDE.md
@@ -308,7 +308,7 @@ A comprehensive rule enforcement system designed for AI-powered development that
 # Analyze PR check failures
 ./.claude/hooks/pr-check-handler.sh [PR_NUMBER]
 
-# Report cursor_rules issues
+# Report vibe-codex issues
 ./.claude/hooks/report-issue.sh
 ```
 
@@ -576,7 +576,7 @@ git commit -m "test: debug mode" --verbose
 ## LLM Integration
 
 ### For AI Assistants
-This section provides guidance for AI assistants working with cursor_rules.
+This section provides guidance for AI assistants working with vibe-codex.
 
 #### Primary Reference Documents
 1. **MANDATORY-RULES.md**: Complete rule reference (LLM-optimized)

--- a/hooks/report-issue.sh
+++ b/hooks/report-issue.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Report issues with cursor_rules to the repository
+# Report issues with vibe-codex to the repository
 
-echo "📝 Cursor Rules Issue Reporter"
+echo "📝 Vibe Codex Issue Reporter"
 echo "=============================" 
 
 # Check for GitHub CLI
@@ -75,7 +75,7 @@ ${ISSUE_BODY}
 <!-- Any ideas on how to improve the rule? -->
 
 ---
-*Reported via cursor-rules issue reporter*
+*Reported via vibe-codex issue reporter*
 EOF
 )
 
@@ -83,8 +83,11 @@ EOF
 echo ""
 echo "Creating issue in vibe-codex repository..."
 
+# Get repository from environment or default
+REPO="${VIBE_CODEX_REPO:-your-org/vibe-codex}"
+
 gh issue create \
-  --repo tyabonil/vibe-codex \
+  --repo "$REPO" \
   --title "${ISSUE_PREFIX}${ISSUE_TITLE}" \
   --body "$FULL_BODY" \
   --label "$ISSUE_LABEL"

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -25,6 +25,7 @@ const {
 const logger = require("../utils/logger");
 const { createRollbackPoint, rollback } = require("../utils/rollback");
 const { processInitArgs } = require("../utils/cli-args");
+const defaults = require("../config/defaults");
 
 module.exports = async function init(options) {
   console.log(chalk.blue("\n🎯 Welcome to vibe-codex!\n"));
@@ -311,5 +312,5 @@ function showSuccessMessage(
       `   ${packageManager === "npm" ? "npx" : runCmd} vibe-codex --help`,
     ),
   );
-  console.log(chalk.gray("   https://github.com/tyabonil/vibe-codex"));
+  console.log(chalk.gray(`   https://github.com/${defaults.repository.repo}`));
 }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -9,6 +9,7 @@ const fs = require("fs-extra");
 const { installRules, downloadFile } = require("../installer/rules");
 const { downloadHookScripts } = require("../installer/hooks-downloader");
 const { installGitHooks } = require("../installer/git-hooks");
+const defaults = require("../config/defaults");
 
 module.exports = async function update(options) {
   const spinner = ora("Checking for updates...").start();
@@ -49,8 +50,8 @@ module.exports = async function update(options) {
     spinner.start("Updating MANDATORY rules...");
     try {
       await downloadFile(
-        "https://raw.githubusercontent.com/tyabonil/vibe-codex/main/MANDATORY-RULES.md",
-        "MANDATORY-RULES.md",
+        `${defaults.repository.baseUrl}/${defaults.rules.mandatory}`,
+        defaults.rules.mandatory,
       );
       spinner.succeed("MANDATORY rules updated");
     } catch (error) {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,0 +1,44 @@
+/**
+ * Default configuration values for vibe-codex
+ * These can be overridden by environment variables or configuration files
+ */
+
+module.exports = {
+  // Repository configuration
+  repository: {
+    // Base URL for downloading rules and templates
+    // Can be overridden with VIBE_CODEX_REPO_URL environment variable
+    baseUrl: process.env.VIBE_CODEX_REPO_URL || 'https://raw.githubusercontent.com/your-org/vibe-codex/main',
+    
+    // Repository owner and name for API calls
+    // Can be overridden with VIBE_CODEX_REPO environment variable
+    repo: process.env.VIBE_CODEX_REPO || 'your-org/vibe-codex'
+  },
+  
+  // File and directory names
+  files: {
+    // Configuration file name
+    config: '.vibe-codex.json',
+    
+    // Ignore file name
+    ignore: '.vibe-codexignore',
+    
+    // Work directory
+    workDir: '.vibe-codex',
+    
+    // Backup directory
+    backupDir: '.vibe-codex-backup'
+  },
+  
+  // Default rule files
+  rules: {
+    mandatory: 'MANDATORY-RULES.md',
+    context: 'PROJECT_CONTEXT.md'
+  },
+  
+  // Hook configuration
+  hooks: {
+    // Base path for downloading hooks
+    basePath: 'hooks'
+  }
+};

--- a/lib/installer/hooks-downloader.js
+++ b/lib/installer/hooks-downloader.js
@@ -7,9 +7,9 @@ const path = require("path");
 const fetch = require("node-fetch");
 const chalk = require("chalk");
 const logger = require("../utils/logger");
+const defaults = require("../config/defaults");
 
-const HOOKS_BASE_URL =
-  "https://raw.githubusercontent.com/tyabonil/vibe-codex/main/hooks";
+const HOOKS_BASE_URL = `${defaults.repository.baseUrl}/${defaults.hooks.basePath}`;
 
 const HOOK_SCRIPTS = {
   "enhanced-pre-commit.sh": "Comprehensive pre-commit validation",

--- a/lib/installer/rules.js
+++ b/lib/installer/rules.js
@@ -6,11 +6,10 @@ const fs = require("fs-extra");
 const path = require("path");
 const chalk = require("chalk");
 const fetch = require("node-fetch");
+const defaults = require("../config/defaults");
 
-const RULES_URL =
-  "https://raw.githubusercontent.com/tyabonil/vibe-codex/main/MANDATORY-RULES.md";
-const PROJECT_CONTEXT_URL =
-  "https://raw.githubusercontent.com/tyabonil/vibe-codex/main/PROJECT_CONTEXT.md";
+const RULES_URL = `${defaults.repository.baseUrl}/${defaults.rules.mandatory}`;
+const PROJECT_CONTEXT_URL = `${defaults.repository.baseUrl}/${defaults.rules.context}`;
 
 /**
  * Install MANDATORY rules and related files

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "cli",
     "npx"
   ],
-  "homepage": "https://github.com/tyabonil/vibe-codex",
+  "homepage": "https://github.com/your-org/vibe-codex",
   "bugs": {
-    "url": "https://github.com/tyabonil/vibe-codex/issues"
+    "url": "https://github.com/your-org/vibe-codex/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tyabonil/vibe-codex.git"
+    "url": "git+https://github.com/your-org/vibe-codex.git"
   },
   "license": "MIT",
-  "author": "Ty Yabonil",
+  "author": "",
   "main": "lib/index.js",
   "bin": {
     "vibe-codex": "bin/vibe-codex.js"


### PR DESCRIPTION
## Summary
- Removed all project-specific implementations to make vibe-codex universally applicable
- Made repository URLs configurable via environment variables
- Removed author-specific information

## Changes
- Created `lib/config/defaults.js` for configurable repository URLs
- Updated `package.json` to use generic repository URLs
- Removed author name from package.json and README
- Updated all hardcoded repository references to use configuration
- Removed references to cursor_rules (predecessor project)
- Made repository configurable via environment variables
- Added `CONFIGURATION.md` explaining customization options

## Configuration
Users can now configure vibe-codex for their organization using environment variables:
- `VIBE_CODEX_REPO_URL`: Base URL for downloading rules/templates
- `VIBE_CODEX_REPO`: GitHub repository for API calls

Example:
```bash
export VIBE_CODEX_REPO_URL=https://raw.githubusercontent.com/mycompany/our-rules/main
export VIBE_CODEX_REPO=mycompany/our-rules
npx vibe-codex init --type=web --preset
```

## Related Issues
- Closes #350

## Test Plan
- [x] All hardcoded references removed
- [x] Environment variables work correctly
- [x] Documentation updated
- [x] No project-specific information remains

🤖 Generated with [Claude Code](https://claude.ai/code)